### PR TITLE
Stop using `init()` to setup cobra commands

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,11 +26,12 @@ import (
 	"github.com/endorama/devid/internal/backup"
 )
 
-// backupCmd represents the backup command.
-var backupCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "backup",
-	Short: "backup a persona",
-	Long: `Create encrypted backup of a persona.
+func Backup() *cobra.Command {
+	// backupCmd represents the backup command.
+	var backupCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
+		Use:   "backup",
+		Short: "backup a persona",
+		Long: `Create encrypted backup of a persona.
 
 The backup is compressed (.tar.gz) and encrypted using age (filippo.io/age).
 Encryption requires a passphrase that is automatically generated using a safe 
@@ -39,36 +40,36 @@ RNG function and printed after backup creation.
 This command loads the current persona from DEVID_ACTIVE_PERSONA environment variable, and this 
 value takes precedence over the --persona flag.
 `,
-	Args: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		p, err := utils.LoadPersona(cmd)
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), noPersonaLoadedExitCode)
-		}
-		passphrase := utils.GeneratePassphrase()
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := utils.LoadPersona(cmd)
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), noPersonaLoadedExitCode)
+			}
+			passphrase := utils.GeneratePassphrase()
 
-		ui.Outputf(fmt.Sprintf("creating backup for persona: %s\n", p.Name()))
+			ui.Outputf(fmt.Sprintf("creating backup for persona: %s\n", p.Name()))
 
-		out, err := os.Create(fmt.Sprintf("%s.tar.gz.age", p.Name()))
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot create file: %w", err), genericExitCode)
-		}
-		defer out.Close()
+			out, err := os.Create(fmt.Sprintf("%s.tar.gz.age", p.Name()))
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot create file: %w", err), genericExitCode)
+			}
+			defer out.Close()
 
-		b, err := backup.NewTask(p.Name(), p.Location(), out)
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot create backup task: %w", err), genericExitCode)
-		}
-		err = backup.Perform(b, passphrase)
-		if err != nil {
-			ui.Fatal(err, genericExitCode)
-		}
+			b, err := backup.NewTask(p.Name(), p.Location(), out)
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot create backup task: %w", err), genericExitCode)
+			}
+			err = backup.Perform(b, passphrase)
+			if err != nil {
+				ui.Fatal(err, genericExitCode)
+			}
 
-		ui.Infof("Encryption passphrase is: %s", passphrase)
-	},
-}
-
-func init() { //nolint:gochecknoinits // required by cobra
+			ui.Infof("Encryption passphrase is: %s", passphrase)
+		},
+	}
 	backupCmd.Flags().String("persona", "", "The persona to backup")
-	rootCmd.AddCommand(backupCmd)
+
+	return backupCmd
+
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/endorama/devid/cmd/ui"
+	"github.com/spf13/cobra"
+)
+
+var cli *cobra.Command
+
+// Init initialises a cobra CLI with all commands from this package.
+func Init() {
+	cli = RootCmd()
+	cli.AddCommand(
+		Backup(),
+		Delete(),
+		Edit(),
+		List(),
+		New(),
+		Rehash(),
+		Shell(),
+		Whoami(),
+	)
+}
+
+// Execute perform execution of the global CLI initialised with Init().
+// panics if Init() has not been called.
+func Execute() {
+	if cli == nil {
+		panic("cli has not been initialised, have you called Init()?")
+	}
+
+	if err := cli.Execute(); err != nil {
+		ui.Fatal(err, genericExitCode)
+	}
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,11 +25,11 @@ import (
 	"github.com/endorama/devid/cmd/utils"
 )
 
-// deleteCmd represents the delete command.
-var deleteCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "delete",
-	Short: "delete a persona",
-	Long: `Delete a persona using a secure deletion function.
+func Delete() *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "delete a persona",
+		Long: `Delete a persona using a secure deletion function.
 
 All content from the persona's folder will be destroyed through this command.
 
@@ -43,24 +43,24 @@ further details.
 This command loads the current persona from DEVID_ACTIVE_PERSONA environment variable, and this 
 value takes precedence over the --persona flag.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		p, err := utils.LoadPersona(cmd)
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), noPersonaLoadedExitCode)
-		}
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := utils.LoadPersona(cmd)
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), noPersonaLoadedExitCode)
+			}
 
-		// TODO: ask for confirmation (and add it to command docs)
+			// TODO: ask for confirmation (and add it to command docs)
 
-		shredTimes := 3
-		shredconf := shred.Conf{Times: shredTimes, Zeros: true, Remove: true}
-		err = shredconf.Dir(p.Location())
-		if err != nil {
-			ui.Fatal(err, genericExitCode)
-		}
-	},
-}
+			shredTimes := 3
+			shredconf := shred.Conf{Times: shredTimes, Zeros: true, Remove: true}
+			err = shredconf.Dir(p.Location())
+			if err != nil {
+				ui.Fatal(err, genericExitCode)
+			}
+		},
+	}
 
-func init() { //nolint:gochecknoinits // required by cobra
 	deleteCmd.Flags().String("persona", "", "The persona to delete")
-	rootCmd.AddCommand(deleteCmd)
+
+	return deleteCmd
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,11 +25,11 @@ import (
 	"github.com/endorama/devid/internal/utils"
 )
 
-// editCmd represents the edit command.
-var editCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "edit",
-	Short: "edit a persona definition file in your $EDITOR",
-	Long: fmt.Sprintf(`Open within EDITOR the specified persona configuration file.
+func Edit() *cobra.Command {
+	editCmd := &cobra.Command{ //nolint:gochecknoglobals // required by cobra
+		Use:   "edit",
+		Short: "edit a persona definition file in your $EDITOR",
+		Long: fmt.Sprintf(`Open within EDITOR the specified persona configuration file.
 
 For security EDITOR variable content is matched against a list of valid editor executable paths.
 NOTE however that if some of this commands are not available on your system is still possible to 
@@ -40,20 +40,20 @@ Allowed EDITOR values: %s
 This command loads the current persona from DEVID_ACTIVE_PERSONA environment variable, and this 
 value takes precedence over the --persona flag.
 `, utils.AllowedEditors),
-	Run: func(cmd *cobra.Command, args []string) {
-		p, err := cmdutils.LoadPersona(cmd)
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), genericExitCode)
-		}
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := cmdutils.LoadPersona(cmd)
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), genericExitCode)
+			}
 
-		err = utils.OpenWithEditor(p.File())
-		if err != nil {
-			ui.Fatal(err, genericExitCode)
-		}
-	},
-}
+			err = utils.OpenWithEditor(p.File())
+			if err != nil {
+				ui.Fatal(err, genericExitCode)
+			}
+		},
+	}
 
-func init() { //nolint:gochecknoinits // required by cobra
 	editCmd.Flags().String("persona", "", "The persona to backup")
-	rootCmd.AddCommand(editCmd)
+
+	return editCmd
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,26 +27,26 @@ import (
 )
 
 // listCmd represents the list command.
-var listCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "list",
-	Short: "list personas",
-	Long:  `List all available personas.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		files, err := ioutil.ReadDir(viper.GetString("personas_location"))
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot read folder content: %w", err), noPersonaLoadedExitCode)
-		}
-		for _, f := range files {
-			if f.IsDir() {
-				p, _ := persona.New(f.Name())
-				if p.Exists() {
-					ui.Outputf(p.Name())
+func List() *cobra.Command {
+	listCmd := &cobra.Command{ //nolint:gochecknoglobals // required by cobra
+		Use:   "list",
+		Short: "list personas",
+		Long:  `List all available personas.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			files, err := ioutil.ReadDir(viper.GetString("personas_location"))
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot read folder content: %w", err), noPersonaLoadedExitCode)
+			}
+			for _, f := range files {
+				if f.IsDir() {
+					p, _ := persona.New(f.Name())
+					if p.Exists() {
+						ui.Outputf(p.Name())
+					}
 				}
 			}
-		}
-	},
-}
+		},
+	}
 
-func init() { //nolint:gochecknoinits // required by cobra
-	rootCmd.AddCommand(listCmd)
+	return listCmd
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,10 +28,11 @@ import (
 )
 
 // newCmd represents the new command.
-var newCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "new [name]",
-	Short: "create a persona",
-	Long: fmt.Sprintf(`Create a new, empty, persona configuration file, opens it within EDITOR.
+func New() *cobra.Command {
+	newCmd := &cobra.Command{ //nolint:gochecknoglobals // required by cobra
+		Use:   "new [name]",
+		Short: "create a persona",
+		Long: fmt.Sprintf(`Create a new, empty, persona configuration file, opens it within EDITOR.
 
 For security EDITOR variable content is matched against a list of valid editor executable paths.
 NOTE however that if some of this commands are not available on your system is still possible to 
@@ -39,15 +40,14 @@ trigger an unknown command execution trough this command.
 
 Allowed EDITOR values: %s
 `, utils.AllowedEditors),
-	Args: cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runCommand(args)
-	},
-}
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runCommand(args)
+		},
+	}
 
-func init() { //nolint:gochecknoinits // required by cobra
 	// add --overwrite to overwrite already existing profile
-	rootCmd.AddCommand(newCmd)
+	return newCmd
 }
 
 func runCommand(args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,11 +31,12 @@ import (
 var cfgFile string //nolint:gochecknoglobals // required for init
 var verbose bool   //nolint:gochecknoglobals // require for init
 
-// rootCmd represents the base command when called without any subcommands.
-var rootCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "devid",
-	Short: "Secure manager for your developer personas",
-	Long: `devid (pronounced /ˈdeɪvɪd/) is a Swiss Army Knife for your developer identity personas.
+func RootCmd() *cobra.Command {
+	// rootCmd represents the base command when called without any subcommands.
+	var rootCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
+		Use:   "devid",
+		Short: "Secure manager for your developer personas",
+		Long: `devid (pronounced /ˈdeɪvɪd/) is a Swiss Army Knife for your developer identity personas.
 
 Each of us has multiple personas for different areas of their life. It may be work/personal, or for
 different open source projects, for different clients, or whatever reason you may think for 
@@ -50,28 +51,24 @@ Environment variables:
 - DEVID_PERSONAS_LOCATION (default $XDG_DATA_HOME/devid/personas): specify where devid will look 
 for persona's folders.
 `,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if !verbose {
-			log.SetOutput(ioutil.Discard)
-		}
-	},
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		ui.Fatal(err, genericExitCode)
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if !verbose {
+				log.SetOutput(ioutil.Discard)
+			}
+		},
 	}
-}
-
-func init() { //nolint:gochecknoinits // required by cobra
-	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.devid.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "enable diagnostic logs")
 
 	rootCmd.AddCommand(manager.LoadCommands()...)
+
+	return rootCmd
+}
+
+func init() { //nolint:gochecknoinits // required by cobra
+	cobra.OnInitialize(initConfig)
+
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -13,33 +13,33 @@ import (
 	"github.com/endorama/devid/cmd/utils"
 )
 
-var shellCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "shell",
-	Short: "load a shell preconfigured with persona environment",
-	Long: `Execute the load.sh file of the specified persona, loading the environment,
+func Shell() *cobra.Command {
+	shellCmd := &cobra.Command{ //nolint:gochecknoglobals // required by cobra
+		Use:   "shell",
+		Short: "load a shell preconfigured with persona environment",
+		Long: `Execute the load.sh file of the specified persona, loading the environment,
 
 This command loads the current persona from DEVID_ACTIVE_PERSONA environment variable, and this 
 value takes precedence over the --persona flag.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		p, err := utils.LoadPersona(cmd)
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), noPersonaLoadedExitCode)
-		}
-		if !p.Exists() {
-			ui.Fatal(errPersonaDontExists, genericExitCode)
-		}
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := utils.LoadPersona(cmd)
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), noPersonaLoadedExitCode)
+			}
+			if !p.Exists() {
+				ui.Fatal(errPersonaDontExists, genericExitCode)
+			}
 
-		shellLoaderFilePath := path.Join(p.Location(), viper.GetString("shell_loader_filename"))
+			shellLoaderFilePath := path.Join(p.Location(), viper.GetString("shell_loader_filename"))
 
-		//#nosec G204 -- shellLoaderFilePath is not user controlled (check shell_loader_filename settings)
-		err = syscall.Exec("/usr/bin/env", []string{"bash", shellLoaderFilePath}, os.Environ())
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot exec load file: %w", err), genericExitCode)
-		}
-	},
-}
+			//#nosec G204 -- shellLoaderFilePath is not user controlled (check shell_loader_filename settings)
+			err = syscall.Exec("/usr/bin/env", []string{"bash", shellLoaderFilePath}, os.Environ())
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot exec load file: %w", err), genericExitCode)
+			}
+		},
+	}
 
-func init() { //nolint:gochecknoinits // required by cobra
 	shellCmd.Flags().String("persona", "", "The persona's shell to load")
-	rootCmd.AddCommand(shellCmd)
+	return shellCmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,15 +23,15 @@ import (
 )
 
 // versionCmd represents the version command.
-var versionCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "version",
-	Short: "print version",
-	Long:  `Print version information bundled with the program.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		ui.Outputf(version.BuildString())
-	},
-}
+func VersionCmd() *cobra.Command {
+	versionCmd := &cobra.Command{ //nolint:gochecknoglobals // required by cobra
+		Use:   "version",
+		Short: "print version",
+		Long:  `Print version information bundled with the program.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			ui.Outputf(version.BuildString())
+		},
+	}
 
-func init() { //nolint:gochecknoinits // required by cobra
-	rootCmd.AddCommand(versionCmd)
+	return versionCmd
 }

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,58 +28,58 @@ import (
 )
 
 // whoamiCmd represents the whoami command.
-var whoamiCmd = &cobra.Command{ //nolint:gochecknoglobals // required by cobra
-	Use:   "whoami",
-	Short: "print current loaded persona",
-	Long: `Print information about persona currently loaded.
+func Whoami() *cobra.Command {
+	whoamiCmd := &cobra.Command{ //nolint:gochecknoglobals // required by cobra
+		Use:   "whoami",
+		Short: "print current loaded persona",
+		Long: `Print information about persona currently loaded.
 
 If no persona is loaded print nothing and exit with code 128.
 
 This command loads the current persona from DEVID_ACTIVE_PERSONA environment variable, and this 
 value takes precedence over the --persona flag.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		p, err := utils.LoadPersona(cmd)
-		if err != nil {
-			ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), noPersonaLoadedExitCode)
-		}
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := utils.LoadPersona(cmd)
+			if err != nil {
+				ui.Fatal(fmt.Errorf("cannot instantiate persona: %w", err), noPersonaLoadedExitCode)
+			}
 
-		extended, err := cmd.Flags().GetBool("extended")
-		if err != nil {
-			ui.Error(fmt.Errorf("cannot access flag extended: %w", err))
-		}
+			extended, err := cmd.Flags().GetBool("extended")
+			if err != nil {
+				ui.Error(fmt.Errorf("cannot access flag extended: %w", err))
+			}
 
-		if extended {
-			if errs, err := manager.LoadCorePlugins(p.Config); err != nil {
-				ui.Error(errLoadingCorePlugins)
+			if extended {
+				if errs, err := manager.LoadCorePlugins(p.Config); err != nil {
+					ui.Error(errLoadingCorePlugins)
 
-				for _, e := range errs {
-					ui.Error(e)
+					for _, e := range errs {
+						ui.Error(e)
+					}
+
+					os.Exit(pluginManagerCoreLoadingErrorExitCode)
 				}
 
-				os.Exit(pluginManagerCoreLoadingErrorExitCode)
+				plg, found := manager.GetPlugin("identity")
+				if !found {
+					ui.Fatal(errIdentityPluginNotFound, genericExitCode)
+				}
+
+				identityPlugin, ok := plg.Instance.(*identity.Plugin)
+				if !ok {
+					ui.Fatal(errPluginNotInstanceOf, genericExitCode)
+				}
+
+				ui.Outputf("%s, %s", p.Name(), identityPlugin.Whoami())
+				os.Exit(0)
 			}
 
-			plg, found := manager.GetPlugin("identity")
-			if !found {
-				ui.Fatal(errIdentityPluginNotFound, genericExitCode)
-			}
-
-			identityPlugin, ok := plg.Instance.(*identity.Plugin)
-			if !ok {
-				ui.Fatal(errPluginNotInstanceOf, genericExitCode)
-			}
-
-			ui.Outputf("%s, %s", p.Name(), identityPlugin.Whoami())
+			ui.Outputf(p.Name())
 			os.Exit(0)
-		}
+		},
+	}
 
-		ui.Outputf(p.Name())
-		os.Exit(0)
-	},
-}
-
-func init() { //nolint:gochecknoinits // required by cobra
 	whoamiCmd.Flags().BoolP("extended", "e", false, "Print extended identity information")
-	rootCmd.AddCommand(whoamiCmd)
+	return whoamiCmd
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -30,7 +31,20 @@ func main() {
 
 	createPersonasFolder()
 
-	cmd.Execute()
+	rootCmd := cmd.RootCmd()
+	rootCmd.AddCommand(cmd.Backup())
+	rootCmd.AddCommand(cmd.Delete())
+	rootCmd.AddCommand(cmd.Edit())
+	rootCmd.AddCommand(cmd.List())
+	rootCmd.AddCommand(cmd.New())
+	rootCmd.AddCommand(cmd.Rehash())
+	rootCmd.AddCommand(cmd.Shell())
+	rootCmd.AddCommand(cmd.Whoami())
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }
 
 func createPersonasFolder() {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -31,20 +30,8 @@ func main() {
 
 	createPersonasFolder()
 
-	rootCmd := cmd.RootCmd()
-	rootCmd.AddCommand(cmd.Backup())
-	rootCmd.AddCommand(cmd.Delete())
-	rootCmd.AddCommand(cmd.Edit())
-	rootCmd.AddCommand(cmd.List())
-	rootCmd.AddCommand(cmd.New())
-	rootCmd.AddCommand(cmd.Rehash())
-	rootCmd.AddCommand(cmd.Shell())
-	rootCmd.AddCommand(cmd.Whoami())
-
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	cmd.Init()
+	cmd.Execute()
 }
 
 func createPersonasFolder() {


### PR DESCRIPTION
The `cobra` getting started uses Go `init` functions to initialise commands.

I dislike this practice, is not needed and leverages a pattern that creates trouble.

With this PRs the `cmd` package exposes commands through a exported functions, that are then built into a CLI by the `main` function.
