### PR TITLE
aws: don't configure AWS_PROFILE automatically

### DIFF
--- a/plugins/aws/configurable.go
+++ b/plugins/aws/configurable.go
@@ -11,7 +11,8 @@ type Config struct {
 	// configuration. When true it the plugin will set AWS_CONFIG to a file within the persona
 	// folder.
 	// Default is false.
-	LocalConfig bool `mapstructure:"local_config"`
+	LocalConfig       bool   `mapstructure:"local_config"`
+	CustomProfileName string `mapstructure:"custom_profile_name"`
 }
 
 func (p *Plugin) Configure(v *viper.Viper) error {

--- a/plugins/aws/configurable_test.go
+++ b/plugins/aws/configurable_test.go
@@ -31,6 +31,21 @@ func TestPlugin_Configure(t *testing.T) {
 	assert.Nil(t, err, "err should be nil")
 }
 
+func TestPlugin_ConfigureCustomProfileName(t *testing.T) {
+	config := plugintest.GetConfig(t, "charlie").Sub("aws")
+	require.NotNil(t, config)
+
+	p := aws.NewPlugin()
+
+	err := p.Configure(config)
+	if err != nil {
+		t.Errorf(fmt.Errorf("cannot load plugin config: %w", err).Error())
+	}
+
+	require.Nil(t, err, "err should be nil")
+	require.Equal(t, "foobar", p.Config().CustomProfileName)
+}
+
 func TestPlugin_ConfigureLocalConfig(t *testing.T) {
 	config := plugintest.GetConfig(t, "bob").Sub("aws")
 	require.NotNil(t, config)

--- a/plugins/aws/renderable.go
+++ b/plugins/aws/renderable.go
@@ -16,6 +16,7 @@ func (p *Plugin) Render(personaName, personaDirectory string) string {
 		if p.config.CustomProfileName == "$PERSONA" {
 			profile = personaName
 		}
+
 		sb.WriteString("export AWS_PROFILE=\"" + profile + "\"\n")
 	}
 

--- a/plugins/aws/renderable.go
+++ b/plugins/aws/renderable.go
@@ -11,7 +11,14 @@ func (p *Plugin) Render(personaName, personaDirectory string) string {
 		sb.WriteString("export AWS_CONFIG_FILE=" + personaDirectory + "/aws/config\n")
 	}
 
-	sb.WriteString("export AWS_PROFILE=\"" + personaName + "\"\n")
+	if p.config.CustomProfileName != "" {
+		profile := p.config.CustomProfileName
+		if p.config.CustomProfileName == "$PERSONA" {
+			profile = personaName
+		}
+		sb.WriteString("export AWS_PROFILE=\"" + profile + "\"\n")
+	}
+
 	sb.WriteString("export AWS_SHARED_CREDENTIALS_FILE=" + personaDirectory + "/aws/credentials\n")
 
 	return sb.String()

--- a/plugins/aws/renderable_test.go
+++ b/plugins/aws/renderable_test.go
@@ -25,8 +25,7 @@ func TestPlugin_Render(t *testing.T) {
 
 	r := i.Render(p.Name(), p.Location())
 
-	expected := `export AWS_PROFILE="alice"
-export AWS_SHARED_CREDENTIALS_FILE=testdata/alice/aws/credentials
+	expected := `export AWS_SHARED_CREDENTIALS_FILE=testdata/alice/aws/credentials
 `
 	assert.Equal(t, expected, r)
 }
@@ -47,8 +46,49 @@ func TestPlugin_RenderWithLocalConfig(t *testing.T) {
 	r := i.Render(p.Name(), p.Location())
 
 	expected := `export AWS_CONFIG_FILE=testdata/bob/aws/config
-export AWS_PROFILE="bob"
 export AWS_SHARED_CREDENTIALS_FILE=testdata/bob/aws/credentials
+`
+	assert.Equal(t, expected, r)
+}
+
+func TestPlugin_RenderWithCustomProfileName(t *testing.T) {
+	config := plugintest.GetConfig(t, "charlie").Sub("aws")
+	require.NotNil(t, config)
+
+	p := plugintest.GetPersona(t, "charlie")
+
+	i := aws.NewPlugin()
+
+	err := i.Configure(config)
+	require.NoError(t, err)
+
+	assert.True(t, plugintest.IsEnabled(t, "aws", p.Config), "plugin is not enabled for this persona")
+
+	r := i.Render(p.Name(), p.Location())
+
+	expected := `export AWS_PROFILE="foobar"
+export AWS_SHARED_CREDENTIALS_FILE=testdata/charlie/aws/credentials
+`
+	assert.Equal(t, expected, r)
+}
+
+func TestPlugin_RenderWithCustomProfileNamePersona(t *testing.T) {
+	config := plugintest.GetConfig(t, "dan").Sub("aws")
+	require.NotNil(t, config)
+
+	p := plugintest.GetPersona(t, "dan")
+
+	i := aws.NewPlugin()
+
+	err := i.Configure(config)
+	require.NoError(t, err)
+
+	assert.True(t, plugintest.IsEnabled(t, "aws", p.Config), "plugin is not enabled for this persona")
+
+	r := i.Render(p.Name(), p.Location())
+
+	expected := `export AWS_PROFILE="dan"
+export AWS_SHARED_CREDENTIALS_FILE=testdata/dan/aws/credentials
 `
 	assert.Equal(t, expected, r)
 }

--- a/plugins/aws/testdata/charlie/config.yaml
+++ b/plugins/aws/testdata/charlie/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+identity:
+  email: "charlie@example.com"
+  name: "Charlie Testcase"
+aws:
+  enabled: true
+  custom_profile_name: "foobar"

--- a/plugins/aws/testdata/dan/config.yaml
+++ b/plugins/aws/testdata/dan/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+identity:
+  email: "dan@example.com"
+  name: "Dan Testcase"
+aws:
+  enabled: true
+  custom_profile_name: "$PERSONA"


### PR DESCRIPTION
The `aws` plugin currently always set `AWS_PROFILE` to the persona's name. This is
not necessary, as having multiple personas allow to leverage the default
profile for each without special AWS configurations.

Updates the plugin to accept an additional `custom_profile_name` configuration
that specifies the custom profile name to use. When empty, `AWS_PROFILE` is
not set. When set to `$PERSONA`, the value is replaced with current
persona's name.

**This is a breaking change.**
