### PR TITLE
lock devenv in CI to 0.6.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           name: devenv
       - name: Install devenv.sh
-        run: nix profile install github:cachix/devenv/latest
+        run: nix profile install github:cachix/devenv/v0.6.3
         shell: sh
       - run: devenv ci
       - run: devenv shell task lint
@@ -30,7 +30,7 @@ jobs:
         with:
           name: devenv
       - name: Install devenv.sh
-        run: nix profile install github:cachix/devenv/latest
+        run: nix profile install github:cachix/devenv/v0.6.3
         shell: sh
       - run: devenv ci
       - run: devenv shell task fmt:check
@@ -49,7 +49,7 @@ jobs:
         with:
           name: devenv
       - name: Install devenv.sh
-        run: nix profile install github:cachix/devenv/latest
+        run: nix profile install github:cachix/devenv/v0.6.3
         shell: sh
       - run: devenv ci
       - run: devenv shell task tests:coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v20
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/install-nix-action@v27
+      - uses: cachix/cachix-action@v15
         with:
           name: devenv
       - name: Install devenv.sh
@@ -25,8 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v20
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/install-nix-action@v27
+      - uses: cachix/cachix-action@v15
         with:
           name: devenv
       - name: Install devenv.sh
@@ -44,8 +44,8 @@ jobs:
     runs-on: "${{ matrix.os }}"
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v22
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/install-nix-action@v27
+      - uses: cachix/cachix-action@v15
         with:
           name: devenv
       - name: Install devenv.sh


### PR DESCRIPTION
Updates to devenv after 1.0 are not working as expected, so ensure we have a working CI for the time being.

